### PR TITLE
Start report of repos without teams

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,10 @@ Analyzes a list of audit log export files (from the JS script) for hook/service 
 ### old_repos.py
 Generate a list of empty (should be deleted) repositories as well as untoched repos (might need to be archived).
 
+### repos_without_teams
+
+List all repositories that do not belong to a team. Use -h for more info.
+
 ## Auth
 The API calls need you to authenticate. Generate a "personal access token" on the github settings page, then create a file ``.credentials`` like this:
 
@@ -39,4 +43,4 @@ The API calls need you to authenticate. Generate a "personal access token" on th
 where the first line is your github username and the second line is the token you generated.
 
 ## License
-This code is free software and licensed under an MIT license. &copy; 2015 Fred Wenzel <fwenzel@mozilla.com>. For more information read the file ``LICENSE``.
+This code is free software and licensed under an MIT license. &copy; 2015 Fred Wenzel <fwenzel@mozilla.com>. For more information read the file ``LICENSE``. Unless otherwise noted.


### PR DESCRIPTION
This will be a long open PR, and is not yet ready for review. Comments welcome! And subscribe to this PR if you'd like to review at the end. 
- There are "too many" repositories to do at one pass (currently 1640) to do all the API requests at once.

(Loosely based on [this article](https://medium.com/practical-blend/pull-request-first-f6bb667a9b6#.yd8dut454) by Carlos Perez.
