### PR TITLE
Add a multiorg code_search tool

### DIFF
--- a/client.py
+++ b/client.py
@@ -1,3 +1,7 @@
+
+from datetime import datetime
+import time
+
 from github3 import login
 
 
@@ -16,3 +20,20 @@ def get_github3_client():
     token = get_token()
     gh = login(token=token)
     return gh
+
+
+def sleep_if_rate_limited(gh, verbose=False):
+    rates = gh.rate_limit()
+
+    if not rates['resources']['search']['remaining']:
+        reset_epoch = rates['resources']['search']['reset']
+
+        reset_dt, now = datetime.utcfromtimestamp(reset_epoch), datetime.utcnow()
+
+        if reset_dt > now:
+            sleep_secs = (reset_dt - now).seconds + 1
+
+            if verbose:
+                print('sleeping for', sleep_secs, 'got rate limit', rates['resources']['search'])
+
+            time.sleep(sleep_secs)

--- a/code_search.py
+++ b/code_search.py
@@ -1,0 +1,66 @@
+
+__doc__ = """Searches for code across multiple github orgs."""
+
+import argparse
+import jsonstreams
+import sys
+
+from client import (
+    get_github3_client,
+    sleep_if_rate_limited,
+)
+
+
+DEFAULT_ORGS = [
+    'mozilla',
+    'mozilla-conduit',
+    'mozilla-platform-ops',
+    'mozilla-releng',
+    'mozilla-services',
+    'taskcluster',
+]
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description=__doc__)
+
+    parser.add_argument("query", type=str,
+                        help='code search query. syntax at https://help.github.com/articles/searching-code/')
+    parser.add_argument("--orgs", default=DEFAULT_ORGS, nargs='*',
+                        help='organizations to search (defaults to {})'.format(DEFAULT_ORGS))
+    parser.add_argument("--json",
+                        help='path to output json results', type=str, default=None)
+    parser.add_argument("--verbose", action='store_true',
+                        help='print logins for all changes')
+
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
+    gh = get_github3_client()
+
+    json_fout = jsonstreams.Stream(jsonstreams.Type.array, args.json, indent=4) if args.json else None
+
+    for org in args.orgs:
+        full_query = 'org:{} {}'.format(org, args.query)
+
+        if args.verbose:
+            print('searching with query {}'.format(full_query))
+
+        sleep_if_rate_limited(gh, verbose=args.verbose)
+
+        print("{0:<16}{1:<32}{2:<64}".format('org', 'repo', 'file path'))
+        for result in gh.search_code(full_query):
+            print("{0:<16}{1.repository.name:<32}{1.path:<64}".format(org, result))
+
+            if json_fout:
+                json_fout.write(result.to_json())
+
+    if json_fout:
+        # must explicitly close -- that's what outputs the closing delimiter
+        json_fout.close()
+
+
+if __name__ == '__main__':
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 github3.py==1.0.0a4
+jsonstreams==0.4.1
 PyYaml==3.11
 tinydb==3.2.1
 # until up on pypa


### PR DESCRIPTION
This is pulled out of another PR per Hal's suggestion to minimize `.credentials` file proliferation.

Adds a script to facilitate searching for code in multiple orgs.

r? @hwine 