### PR TITLE
Allow credentials to be supplied via environment variables

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,6 +32,10 @@ repos:
       #    - id: markdownlint # Configure in .mdlrc
       #      exclude: ^(CODE_OF_CONDUCT.md|README.md)$
     - id: shellcheck
+      args: [
+        "-e", "SC2128",  # allow non-index on array (yields first element)
+        "-e", "SC2155",  # allow declare & assign
+      ]
 
 - repo: https://github.com/IamTheFij/docker-pre-commit
   rev: v2.0.0

--- a/Makefile
+++ b/Makefile
@@ -13,8 +13,8 @@ help:
 	@echo ""
 	@echo "    help          this message"
 	@echo "    build         create a docker image based on working directory"
-	@echo "    run-dev       run a docker image previously created"
-	@echo "    run-update    run with modifiable current directory"
+	@echo "    run           run a docker image previously created"
+	@echo "    run-edit      run with modifiable current directory"
 	@echo "    jupyter 	 run local (non docker) jupyter server for development"
 	@echo "    $(VENV_NAME)  create a local virtualenv for old style development"
 
@@ -40,10 +40,10 @@ build:
 		; \
 	'
 
-# For `run-dev`, we use the configs baked into the image at the time of
+# For `run`, we use the configs baked into the image at the time of
 # the build, so we get what we expect.
-.PHONY: run-dev
-run-dev:
+.PHONY: run
+run:
 	$(SHELL) -c ' ( source set_secrets_in_env.sh $(SOPS_credentials); \
 		docker run --rm --publish-all \
 			--env "GITHUB_PAT" \
@@ -58,10 +58,10 @@ run-dev:
 		wait $$job_pid ; \
 	) '
 
-# For `run-update`, we're mapping the current directory atop the home
+# For `run-edit`, we're mapping the current directory atop the home
 # directory
-.PHONY: run-update
-run-update:
+.PHONY: run-edit
+run-edit:
 	$(SHELL) -c ' ( source set_secrets_in_env.sh $(SOPS_credentials); \
 		docker run --rm --publish-all \
 			$(DOCKER_OPTS) \
@@ -84,9 +84,9 @@ jupyter:
 		jupyter-notebook ; \
 	) '
 
-.PHONY: debug-update
-debug-update:
-	$(MAKE) DOCKER_OPTS="--security-opt=seccomp:unconfined" run-update
+.PHONY: debug-edit
+debug-edit:
+	$(MAKE) DOCKER_OPTS="--security-opt=seccomp:unconfined" run-edit
 
 
 # vim: noet ts=8

--- a/Makefile
+++ b/Makefile
@@ -44,11 +44,7 @@ build:
 # the build, so we get what we expect.
 .PHONY: run-dev
 run-dev:
-	$(SHELL) -c ' test -s "$(SECOPS_SOPS_PATH)" -a -d "$(SECOPS_SOPS_PATH)" || { echo "SECOPS_SOPS_PATH must be set"; exit 3; }'
-	$(SHELL) -c ' ( export GITHUB_PAT=$$(sops -d --extract "[\"GitHub creds\"][\"token\"]" $(SOPS_credentials)) ; \
-		[[ -z $$GITHUB_PAT ]] && exit 3 ; \
-		export CIS_CLIENT_ID=$$(sops -d --extract "[\"Person API creds\"][\"person api client id\"]" $(SOPS_credentials)) ; \
-		export CIS_CLIENT_SECRET=$$(sops -d --extract "[\"Person API creds\"][\"person api client secret\"]" $(SOPS_credentials)) ; \
+	$(SHELL) -c ' ( source set_secrets_in_env.sh $(SOPS_credentials); \
 		docker run --rm --publish-all \
 			--env "GITHUB_PAT" \
 			--env "CIS_CLIENT_ID" \
@@ -66,11 +62,7 @@ run-dev:
 # directory
 .PHONY: run-update
 run-update:
-	$(SHELL) -c ' test -s "$(SECOPS_SOPS_PATH)" -a -d "$(SECOPS_SOPS_PATH)" || { echo "SECOPS_SOPS_PATH must be set"; exit 3; }'
-	$(SHELL) -c ' ( export GITHUB_PAT=$$(sops -d --extract "[\"GitHub creds\"][\"token\"]" $(SOPS_credentials)) ; \
-		[[ -z $$GITHUB_PAT ]] && exit 3 ; \
-		export CIS_CLIENT_ID=$$(sops -d --extract "[\"Person API creds\"][\"person api client id\"]" $(SOPS_credentials)) ; \
-		export CIS_CLIENT_SECRET=$$(sops -d --extract "[\"Person API creds\"][\"person api client secret\"]" $(SOPS_credentials)) ; \
+	$(SHELL) -c ' ( source set_secrets_in_env.sh $(SOPS_credentials); \
 		docker run --rm --publish-all \
 			$(DOCKER_OPTS) \
 			--env "GITHUB_PAT" \
@@ -88,11 +80,7 @@ run-update:
 
 .PHONY: jupyter
 jupyter:
-	$(SHELL) -c ' test -s "$(SECOPS_SOPS_PATH)" -a -d "$(SECOPS_SOPS_PATH)" || { echo "SECOPS_SOPS_PATH must be set"; exit 3; }'
-	$(SHELL) -c ' ( export GITHUB_PAT=$$(sops -d --extract "[\"GitHub creds\"][\"token\"]" $(SOPS_credentials)) ; \
-		[[ -z $$GITHUB_PAT ]] && exit 3 ; \
-		export CIS_CLIENT_ID=$$(sops -d --extract "[\"Person API creds\"][\"person api client id\"]" $(SOPS_credentials)) ; \
-		export CIS_CLIENT_SECRET=$$(sops -d --extract "[\"Person API creds\"][\"person api client secret\"]" $(SOPS_credentials)) ; \
+	$(SHELL) -c ' ( source set_secrets_in_env.sh $(SOPS_credentials); \
 		jupyter-notebook ; \
 	) '
 

--- a/README.md
+++ b/README.md
@@ -30,8 +30,8 @@ _(See `README.md` files in the `binder/` directory tree for more info on buildin
 The Makefile contains targets for building and running the docker images. Invoke
 `make` without arguments to see those targets
 
-- **NOTE**: the docker image only accepts credentials via [sops][sops]. The
-  environment variable "`SECOPS_SOPS_PATH`" must be set appropriately.
+- **NOTE**: the docker image allows credentials to be supplied via [sops][sops].
+  The environment variable "`SECOPS_SOPS_PATH`" must be set appropriately.
 
 [sops]: https://github.com/mozilla/sops
 

--- a/notebooks/UserSearchPy3.ipynb
+++ b/notebooks/UserSearchPy3.ipynb
@@ -1151,7 +1151,7 @@
     "    # grab the department name, for a heuristic on whether we expect to find perms\n",
     "    expect_github_login = False\n",
     "    match = re.search(r\"^\\s*Dept Name: (?P<dept_name>\\S.*)$\", email_body, re_flags)\n",
-    "    if match:\n",
+    "    if match and not verified_github_login:\n",
     "        department_name = match.groups()[0].lower()\n",
     "        dept_keys_infering_github = [\"firefox\", \"engineering\", \"qa\", \"operations\"]\n",
     "        for key in dept_keys_infering_github:\n",

--- a/set_secrets_in_env.sh
+++ b/set_secrets_in_env.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# this file is to be sourced only, and only by the Makefile
+if [[ "$0" != "${BASH_SOURCE}" ]]; then
+  : # do the normal stuff
+else
+  : # not sourced
+  echo "${0##*/}: not sourced. Run: source $0 $(test $# -gt 0 && printf " %q" "$@")" 1>&2
+  exit 1
+fi
+
+# to support non-secops users, allow the credentials to be pre configured via
+# environment variables.
+
+# We require either:
+#   1. all 3 credentials are supplied via envronment variables &
+#      SECOPS_SOPS_PATH is empty, or
+#   2. SECOPS_SOPS_PATH is supplied & valid, and all 3 credentials are empty
+#      In this case, the relative path to the actual credentials file must be
+#      passed as the first arguement
+
+if [[ -n $GITHUB_PAT && -n $CIS_CLIENT_ID && -n $CIS_CLIENT_SECRET \
+    && -z $SECOPS_SOPS_PATH ]]; then
+    # nothing to do
+    :
+elif [[ -n $SECOPS_SOPS_PATH
+    && -z "${GITHUB_PAT}${CIS_CLIENT_ID}${CIS_CLIENT_SECRET}" ]] ; then
+    if [[ -d $SECOPS_SOPS_PATH && -n "$1" ]]; then
+        SOPS_credentials="$1"
+        export GITHUB_PAT="$(sops -d --extract "[\"GitHub creds\"][\"token\"]" "${SOPS_credentials}")"
+        # if we didn't get anything, something's wrong with config
+        if [[ -z $GITHUB_PAT ]]; then
+          echo "Improperly configured SOPS, see $BASH_SOURCE" >/dev/stderr
+          # don't exit, as we're being sourced and don't want to kill our shell :)
+          false
+        fi
+        export CIS_CLIENT_ID="$(sops -d --extract "[\"Person API creds\"][\"person api client id\"]" "${SOPS_credentials}")"
+        export CIS_CLIENT_SECRET="$(sops -d --extract "[\"Person API creds\"][\"person api client secret\"]" "${SOPS_credentials}")"
+    else
+        echo "Improperly configured SOPS, see $BASH_SOURCE" >/dev/stderr
+        false
+    fi
+else
+    echo "Improperly configured credentials. See $BASH_SOURCE" >/dev/stderr
+    false
+fi


### PR DESCRIPTION
For folks using SOPS, we grab the credentials only in the shell that launches the docker instance. That meant that _only_ folks who used SOPS could use the docker image.

These changes allow the credentials to be supplied in the shell that launches `make`.

The SOPS usage has been changed to minimize the chance of leaving credentials in the outer shell.