### PR TITLE
Add more files to ACL exception list

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -115,7 +115,7 @@
         "filename": "notebooks/UserSearchPy3.ipynb",
         "hashed_secret": "13b897fb3181b06360814e15a2535df2624de13a",
         "is_verified": false,
-        "line_number": 2161,
+        "line_number": 2181,
         "is_secret": false
       }
     ],
@@ -130,5 +130,5 @@
       }
     ]
   },
-  "generated_at": "2023-04-28T14:01:01Z"
+  "generated_at": "2023-05-04T20:09:16Z"
 }

--- a/notebooks/UserSearchPy3.ipynb
+++ b/notebooks/UserSearchPy3.ipynb
@@ -1022,6 +1022,7 @@
     "1. a test to ensure it's not broken when changes are made\n",
     "2. the exception lists, which are the most common update\n",
     "3. the filter code\n",
+    "4. the code to invoke the tests\n",
     "\n",
     "Any change to #2 or #3 will re-run the tests"
    ]
@@ -1058,6 +1059,9 @@
     "    \"\"\"https://github.com/Pocket/particle/blob/8e5e3b45766fb3f93fbf28d8170f522aa8ba0e4f/convert/samples/input/html/audiemega2/Makefile\"\"\",\n",
     "    \"\"\"https://github.com/Pocket/particle/blob/8e5e3b45766fb3f93fbf28d8170f522aa8ba0e4f/convert/samples/input/html/audiemega2/pyproject.toml\"\"\",\n",
     "    \"\"\"https://github.com/mozilla-it/cloudalerts/blob/c3721d1d17f5e987cdc60f3d3d0c161a0b04b5ac/Dockerfile\"\"\",\n",
+    "    \"\"\"https://github.com/mozilla-it/it-sre-bot/blob/27c7a5e11ed48aa38baf676c6406fb3dcb116eaf/package-lock.json\"\"\",\n",
+    "    \"\"\"https://github.com/mozilla-services/splunk-ops/blob/ece2052d252d763fa14382f7d114f7c38e5cb31b/splunk_apps/corelight-app-for-splunk/CorelightForSplunk/bin/corelightforsplunk/aob_py3/httplib2/cacerts.txt\"\"\",\n",
+    "    \"\"\"https://github.com/mozilla-mobile/firefox-android/blob/f3b4a9e8c806fcb51906a0db15d67c95a9a383ba/android-components/components/browser/errorpages/src/main/res/values-is/strings.xml\"\"\",\n",
     "    # should pass (makefile != Makefile)\n",
     "    \"\"\"https://github.com/mozilla-services/cloudops-docs/blob/0ff6ea92e394784aef55abd4b9f8b5d26306fe4b/TeamDiagrams/makefile\"\"\",\n",
     "]\n",
@@ -1079,6 +1083,9 @@
     "    None,  # skipped: Makefile\n",
     "    None,  # skipped: pyproject.toml\n",
     "    None,  # skipped: Dockerfile\n",
+    "    None,  # skipped: package-lock.json\n",
+    "    None,  # skipped: cacerts.txt\n",
+    "    None,  # skipped: strings.xml\n",
     "    (\"\"\"https://github.com/search?type=Code&ref=advsearch&q=repo%3Amozilla-services/cloudops-docs+path%3A\"TeamDiagrams/makefile\"+oremj\"\"\",\n",
     "    \"mozilla-services/cloudops-docs\", \"TeamDiagrams\", \"makefile\"),\n",
     "]\n",
@@ -1123,8 +1130,10 @@
     "# items to ignore -- all heuristically derived\n",
     "\n",
     "# only add extensions or repos that could NEVER contain an ACL definition\n",
-    "filenames_to_skip = {\"setup.py\", \"pyproject.toml\", \"requirements.txt\", \"Makefile\", \"Dockerfile\"}\n",
-    "extensions_to_skip = ( \".ics\", \".md\", \".markdown\", \".rst\", \".der\", \".pem\", \".crt\", \".html\", \".htm\", \".svg\", \".bib\", \".po\")\n",
+    "filenames_to_skip = {\"setup.py\", \"pyproject.toml\", \"requirements.txt\", \"Makefile\", \n",
+    "                     \"Dockerfile\", \"package-lock.json\", \"cacerts.txt\", \"strings.xml\"}\n",
+    "extensions_to_skip = ( \".ics\", \".md\", \".markdown\", \".rst\", \".der\", \".pem\", \".crt\", \n",
+    "                      \".html\", \".htm\", \".svg\", \".bib\", \".po\", )\n",
     "\n",
     "# some orgs have patterns for repo names, take advantage of that\n",
     "repos_to_skip_regexp = set((\n",
@@ -1183,7 +1192,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "fa87e0b3",
+   "id": "bb5e4999",
    "metadata": {
     "hidden": true,
     "init_cell": true
@@ -1281,9 +1290,20 @@
     "        query_string,\n",
     "        None, # fragment\n",
     "    ))\n",
-    "    return new_url, repo, basepath, filename\n",
-    "\n",
-    "# test on any change\n",
+    "    return new_url, repo, basepath, filename"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "fa87e0b3",
+   "metadata": {
+    "hidden": true,
+    "init_cell": true
+   },
+   "outputs": [],
+   "source": [
+    "# test on any change - put in own cell, so failure obvious\n",
     "print(_test_ignore_filters())"
    ]
   },


### PR DESCRIPTION
Some short names show up in Base64 encoding, so ignore in known Base64 files.