### PR TITLE
Hwine/fewer acl recommendations

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -115,7 +115,7 @@
         "filename": "notebooks/UserSearchPy3.ipynb",
         "hashed_secret": "13b897fb3181b06360814e15a2535df2624de13a",
         "is_verified": false,
-        "line_number": 2240,
+        "line_number": 2249,
         "is_secret": false
       }
     ],
@@ -130,5 +130,5 @@
       }
     ]
   },
-  "generated_at": "2023-06-16T21:46:32Z"
+  "generated_at": "2023-06-19T16:28:05Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -115,7 +115,7 @@
         "filename": "notebooks/UserSearchPy3.ipynb",
         "hashed_secret": "13b897fb3181b06360814e15a2535df2624de13a",
         "is_verified": false,
-        "line_number": 2225,
+        "line_number": 2240,
         "is_secret": false
       }
     ],
@@ -130,5 +130,5 @@
       }
     ]
   },
-  "generated_at": "2023-05-24T18:00:29Z"
+  "generated_at": "2023-06-16T21:46:32Z"
 }

--- a/notebooks/UserSearchPy3.ipynb
+++ b/notebooks/UserSearchPy3.ipynb
@@ -915,6 +915,7 @@
     "\n",
     "def check_login_perms(logins, headers=None, ldap=None):\n",
     "    any_perms = []\n",
+    "    logins_with_hits = set()\n",
     "    any_perms.append(\"=\" * 30)\n",
     "    if headers:\n",
     "        any_perms.extend(headers)\n",
@@ -964,9 +965,10 @@
     "                        ),\n",
     "                    )\n",
     "                    any_perms.append(\"\")\n",
+    "                    logins_with_hits.add(login)\n",
     "                else:\n",
     "                    any_perms.append(f\"No permissions found for {login}\")\n",
-    "    return any_perms"
+    "    return any_perms, logins_with_hits"
    ]
   },
   {
@@ -1404,8 +1406,21 @@
     "                try:\n",
     "                    # 2023-05-25 can't use regex in code search, so return context for further processing\n",
     "                    # 2023-06-16 can't get as list in one shot, as it could consume search query limit every restart\n",
+    "                    #            but, even this isn't \"right\" -- some state in\n",
+    "                    #            the iterator appears to be changed prior to\n",
+    "                    #            the network call. I.e. even if the network\n",
+    "                    #            call fails, the iterator has \"advanced\", and\n",
+    "                    #            we're missing some elements.\n",
+    "                    #\n",
+    "                    #            I think the only way around that is to do our\n",
+    "                    #            own iterator, so we can specifically identify\n",
+    "                    #            _when_ we're making network calls, vs\n",
+    "                    #            unpacking another element from the last call.\n",
+    "                    #            Or a hack to reach that deep inside the\n",
+    "                    #            iterator. :/\n",
     "                    hit = hit_iter.next()\n",
     "                    full_list.append(hit)\n",
+    "                    print(f\"so far {len(full_list)}\")\n",
     "                except StopIteration:\n",
     "                    # we have to handle explicily - just set flag\n",
     "                    assume_time_out = False\n",
@@ -1432,7 +1447,7 @@
     "                        print(f\"org={org} l={l} exception={str(e)}\")\n",
     "                    elif e.code in [403]:\n",
     "                        seconds_to_wait = 7\n",
-    "                        print(f\"\\nOut of Code Search API calls, waiting {seconds_to_wait} seconds ({org=}, {l=}) ..\", end='')\n",
+    "                        print(f\"Out of Code Search API calls, waiting {seconds_to_wait} seconds ({org=}, {l=}) ..\", end='')\n",
     "                        # we can hit this a lot, so just wait a minute - only 10 req/min\n",
     "                        #  per https://docs.github.com/en/enterprise-cloud@latest/rest/search?apiVersion=2022-11-28#rate-limit\n",
     "                        time.sleep(seconds_to_wait)\n",
@@ -1710,7 +1725,9 @@
     "        guesses.update({x.login.lower() for x in displayed_users})\n",
     "        display(f\"Checking logins {guesses}\")\n",
     "        msgs = []\n",
-    "        msgs = check_login_perms(guesses, headers)\n",
+    "        msgs, logins_with_hits = check_login_perms(guesses, headers)\n",
+    "        display(f\"resetting guesses to found hits: {logins_with_hits}\")\n",
+    "        guesses = logins_with_hits\n",
     "        found_perms = \"FOUND!\" in \"\".join(msgs)\n",
     "        display(f\"msgs {len(msgs)}; headers {len(headers)}\")\n",
     "        display(\n",
@@ -2141,6 +2158,7 @@
    "cell_type": "markdown",
    "id": "de2fe9a2",
    "metadata": {
+    "heading_collapsed": true,
     "lines_to_next_cell": 0
    },
    "source": [
@@ -2150,7 +2168,9 @@
   {
    "cell_type": "markdown",
    "id": "8a5cd9b9",
-   "metadata": {},
+   "metadata": {
+    "hidden": true
+   },
    "source": [
     "Fill in list of the desired logins in the cell below. Appropriate values may be in the GitHub report."
    ]
@@ -2160,7 +2180,8 @@
    "execution_count": null,
    "id": "9112d45e",
    "metadata": {
-    "scrolled": false
+    "hidden": true,
+    "scrolled": true
    },
    "outputs": [],
    "source": [
@@ -2168,23 +2189,11 @@
     "start = time.time()\n",
     "check_github_acls(\n",
     "    \"\"\" \n",
-    "srosuna srosu srosungnerntitiphan simonarosu srosu58 srosuna1 softvision-simonarosu\n",
+    "\n",
     "\"\"\"\n",
     ")\n",
     "duration = time.time() - start\n",
     "print(f\"done in {int(duration)} seconds\")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "50e5ac4e",
-   "metadata": {
-    "scrolled": false
-   },
-   "outputs": [],
-   "source": [
-    "%debug"
    ]
   },
   {

--- a/notebooks/UserSearchPy3.ipynb
+++ b/notebooks/UserSearchPy3.ipynb
@@ -1398,11 +1398,16 @@
     "#         print(f\" {org}..\", end='')\n",
     "        for l in possibles:\n",
     "            full_list = []\n",
+    "            hit_iter = gh.search_code(query=f\"org:{org} {l}\", text_match=True)\n",
     "            assume_time_out = True\n",
     "            while assume_time_out:\n",
     "                try:\n",
     "                    # 2023-05-25 can't use regex in code search, so return context for further processing\n",
-    "                    full_list = list(gh.search_code(query=f\"org:{org} {l}\", text_match=True))\n",
+    "                    # 2023-06-16 can't get as list in one shot, as it could consume search query limit every restart\n",
+    "                    hit = hit_iter.next()\n",
+    "                    full_list.append(hit)\n",
+    "                except StopIteration:\n",
+    "                    # we have to handle explicily - just set flag\n",
     "                    assume_time_out = False\n",
     "                except Exception as e:\n",
     "                    if isinstance(e, http.client.RemoteDisconnected):\n",
@@ -2136,7 +2141,6 @@
    "cell_type": "markdown",
    "id": "de2fe9a2",
    "metadata": {
-    "heading_collapsed": true,
     "lines_to_next_cell": 0
    },
    "source": [
@@ -2146,9 +2150,7 @@
   {
    "cell_type": "markdown",
    "id": "8a5cd9b9",
-   "metadata": {
-    "hidden": true
-   },
+   "metadata": {},
    "source": [
     "Fill in list of the desired logins in the cell below. Appropriate values may be in the GitHub report."
    ]
@@ -2158,18 +2160,31 @@
    "execution_count": null,
    "id": "9112d45e",
    "metadata": {
-    "hidden": true,
     "scrolled": false
    },
    "outputs": [],
    "source": [
     "print()\n",
+    "start = time.time()\n",
     "check_github_acls(\n",
     "    \"\"\" \n",
-    "\n",
+    "srosuna srosu srosungnerntitiphan simonarosu srosu58 srosuna1 softvision-simonarosu\n",
     "\"\"\"\n",
     ")\n",
-    "print(\"done\")"
+    "duration = time.time() - start\n",
+    "print(f\"done in {int(duration)} seconds\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "50e5ac4e",
+   "metadata": {
+    "scrolled": false
+   },
+   "outputs": [],
+   "source": [
+    "%debug"
    ]
   },
   {


### PR DESCRIPTION
Don't suggest ACL searches for no-hit logins

There's no point in searching for potential GitHub logins that did not
get a member-or-contributor hit on the repos. This should prune the ACL
search to a max of 2 values: ldap & (real) GitHub login.